### PR TITLE
fix html pattern

### DIFF
--- a/namuwiki/_syntax.py
+++ b/namuwiki/_syntax.py
@@ -8,7 +8,7 @@ _patterns = {
     ],
 
     'html': [
-        r'\{\{\{\#\!html[ \t\n]+(?P<text>[\s\S]*?)\}\}\}',
+        r'\{\{\{\#\!html[ \t\n]*(?P<text>[\s\S]*?)\}\}\}',
         r'\[\[html[ \t]*\((?P<text>[^\)]*)\)\]\]', # rigvedawiki syntax
     ],
 


### PR DESCRIPTION
해당 정규식 수정전에는 다음과 같은 형식을 처리하지 못하는 현상이 있었습니다.

```html
{{{#!html<ruby><rb>03式</rb><rt>まるさんしき</rt></ruby>}}} {{{#!html<ruby><rb>中距離地対空誘導弾</rb><rt>ちゅうきょりちたいくうゆうどうだん</rt></ruby>}}}
```

```html
||<tablealign=center><table bgcolor=black><width=250px> [[우드론 역|{{{#!html<div style="font-size:13px"><font color="#FFFFFF">우드론 방면}}}]][[138가-그랜드 콩코스 역|{{{#!html<div style="font"><font color="#FFFFFF">138가-그랜드 콩코스</font>}}}]] || {{{+1 {{{#fff ←}}} }}} ||[[뉴욕 지하철 4호선|[[파일:500px-NYCS-bull-trans-4.png|width=75]]]]|| {{{+1 {{{#fff →}}} }}} ||<width=250px> [[크라운 하이츠-유티카가 역|{{{#!html<div style="font-size:13px"><font color="#FFFFFF">크라운 하이츠-유티카가 방면}}}]][[86가 역(렉싱턴)|{{{#!html<div style="font"><font color="#FFFFFF">86가</font>}}}]] ||
```

위 텍스트를 extract 하면 아래와 같이 출력됩니다.

```html
#!html<ruby <rb>03式</rb><rt>まるさんしき</rt></ruby> #!html<ruby><rb>中距離地対空誘導弾</rb><rt>ちゅうきょりちたいくうゆうどうだん</rt></ruby>
```

```html
#!html<div style=\"font-size:13px\" <font color=\"#FFFFFF\">우드론 방면 #!html<div style=\"font\"><font color=\"#FFFFFF\">138가-그랜드 콩코스</font> ← → #!html<div style=\"font-size:13px\"><font color=\"#FFFFFF\">크라운 하이츠-유티카가 방면 #!html<div style=\"font\"><font color=\"#FFFFFF\">86가</font>\n#!html<div style=\"font-size:13px\" <font color=\"#FFFFFF\">이스트체스터-다이어가 방면 #!html<div style=\"font\"><font color=\"#FFFFFF\">138가-그랜드 콩코스</font> ← → #!html<div style=\"font-size:13px\"><font color=\"#FFFFFF\">플랫부시가-브루클린 칼리지 방면 #!html<div style=\"font\"><font color=\"#FFFFFF\">86가</font>\n#!html<div style=\"font-size:13px\" <font color=\"#FFFFFF\">펠햄 베이 파크 방면 #!html<div style=\"font\"><font color=\"#FFFFFF\">3번가-138가</font> ← → #!html<div style=\"font-size:13px\"><font color=\"#FFFFFF\">브루클린 대교-뉴욕 시청 방면 #!html<div style=\"font\"><font color=\"#FFFFFF\">116가</font>
```

태그 이외의 특수기호들만 처리되고 나머지 태그는 남아있는 모습입니다.

따라서, 공백 없이 태그가 붙어있는 경우도 처리할 수 있도록 메타문자를 +에서 *로 변경하였고, 아래는 변경한 뒤 다시 extract 한 결과입니다.

```
03式まるさんしき 中距離地対空誘導弾ちゅうきょりちたいくうゆうどうだん
```

```
우드론 방면138가-그랜드 콩코스 ← → 크라운 하이츠-유티카가 방면86가\n이스트체스터-다이어가 방면138가-그랜드 콩코스 ← → 플랫부시가-브루클린 칼리지 방면86가
```

원래는 태그와 같이 삭제되어야 하는 내용인듯 하나, 불필요한 태그가 같이 남아있는것보단 텍스트만 남는편이 더 낫다고 생각해서 위와같이 수정합니다.