### PR TITLE
취소선 패턴 추가

### DIFF
--- a/namuwiki/_syntax.py
+++ b/namuwiki/_syntax.py
@@ -34,7 +34,7 @@ _patterns = {
     
     'bold': r"'''(?P<text>.*?)'''",
     'italic': r"''(?P<text>.*?)''",
-    'deletion': r'(~~|--)(?P<text>.*?)\1',
+    'deletion': r'(~~~|~~|--)(?P<text>.*?)\1',
     'underline': r'__(?P<text>.*?)__',
     'superscript': r'\^\^(?P<text>.*?)\^\^',
     'subscript': r',,(?P<text>.*?),,',


### PR DESCRIPTION
물결 (~)이 3개인 취소선 패턴이 있어서 추가했습니다.

## 예시
[https://namu.wiki/raw/F6F%20%ED%97%AC%EC%BA%A3?rev=358](https://namu.wiki/raw/F6F%20%ED%97%AC%EC%BA%A3?rev=358)

> (중략) 이 시기, 헬캣의 경쟁기인 콜세어는 실속시 기체 제어가 곤란하다는 문제점과 항공모함 착함시 발생하는 제어 불능,  기수가 매우 기다란 디자인 탓에 착함시 기수를 들면 전방 시계가 제한된다는 문제점~~~아예 앞이 안보인다~~~을 가지고 있었다. 즉 함재기로 사용이 불가능했었던 상태. 그래서 해군 항공대의 의견에 따라 해병대에게 떠넘겨진 상태였고 그 사이에 그루먼 사가 F6F를 코피를 흘려가며 생산한 덕에 양산기는 모조리 R-2800-10 엔진을 장비한 F6F-3로 채울 수 있었다. (이하 생략)

### 기존 처리 결과

```
...
1964년 제품이다.
둘러보기
~아예 앞이 안보인다
사진에서 진심이 느껴진다. 잘가, 와일드캣
근데 헬캣이 한참 제로센과 치고박고 싸우던 당시 기준, 콜세어를 함재기라고 부를 수 있나?
...
```

### 패턴 추가 후 처리 결과

```
...
1964년 제품이다.
둘러보기
아예 앞이 안보인다
사진에서 진심이 느껴진다. 잘가, 와일드캣
근데 헬캣이 한참 제로센과 치고박고 싸우던 당시 기준, 콜세어를 함재기라고 부를 수 있나?
...
```